### PR TITLE
Added pbis-open-upgrade package compatibility with legacy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,3 +96,5 @@ Please open a pull request with any changes or bugfixes.
 Likewise Open was acquired by BeyondTrust in 2011 and rebranded as PowerBroker Identity Services Open Edition. The project page is at [powerbrokeropen.org](http://www.powerbrokeropen.org).
 
 The original Likewise Open package is included in the Ubuntu repositories, but has not been updated in years.
+
+In Ubuntu 14.04, the Likewise Open package got removed in the default repositories. More details found in [this bug](https://bugs.launchpad.net/ubuntu/+source/likewise-open/+bug/1295031)

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This module supports two ways of distributing the PBIS Open packages:
 
 The default is to use Puppet's built-in fileserver.
 
-In either case, download the necessary packages from the [BeyondTrust website](http://www.beyondtrust.com/Technical-Support/Downloads/PowerBroker-Identity-Services-Open-Edition/?Pass=True). Extract the architecture-specific `pbis-open` `.rpm` or `.deb` file from the self-extracting `sh` archive.
+In either case, download the necessary packages from the [BeyondTrust website](http://download1.beyondtrust.com/Technical-Support/Downloads/PowerBroker-Identity-Services-Open-Edition/?Pass=True). Extract the architecture-specific `pbis-open` `.rpm` or `.deb` file from the self-extracting `sh` archive.
 
 ### Using Puppet's built-in fileserver
 

--- a/README.md
+++ b/README.md
@@ -32,9 +32,13 @@ Rename the `pbis-open` package files according to the following convention:
 
     pbis-open.amd64.deb
     pbis-open.i386.deb
+    pbis-open-upgrade.amd64.deb
+    pbis-open-upgrade.i386.deb
 
     pbis-open.x86_64.rpm
     pbis-open.i386.rpm
+    pbis-open-upgrade.x86_64.rpm
+    pbis-open-upgrade.i386.rpm
     
 and place them in the module's `files/` folder.
 
@@ -59,6 +63,17 @@ The service name may not be 'lsass' on newer version of PBIS and may be 'lwsmd'.
       class { 'pbis':
         ...
         service_name => 'lwsmd',
+      }
+    }
+
+### Compatibility to PBIS <=v7.1.0
+
+PBIS version prior or equal to v7.1.0 do not require the `pbis-open-upgrade` package. Disable it's use by setting:
+
+    node 'workstation' {
+      class { 'pbis':
+        ...
+        package_prerequired => '',
       }
     }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -36,12 +36,14 @@ class pbis (
     
     # Compatibilitity switch for pbis <= v7.1.0
     # require also the prerequired package if it is not set to empty string
-    $require_for_package = File["/opt/${package}.${package_file_suffix}"]
-    if $package_prerequired == true {
-	  $require_for_package = [
-	    $require_for_package,
-	    Package[$package_prerequired]
-	  ]
+    if $package_prerequired == "" {
+	  $require_for_package = File["/opt/${package_prerequired}.${package_file_suffix}"]
+    }
+    else {
+      $require_for_package = [
+        File["/opt/${package_prerequired}.${package_file_suffix}"],
+        Package[$package_prerequired]
+      ]
     }
     
     file { "/opt/${package}.${package_file_suffix}":
@@ -52,10 +54,10 @@ class pbis (
       ensure   => installed,
       source   => "/opt/${package}.${package_file_suffix}",
       provider => $package_file_provider,
-      require  => $require_for_package_full
+      require  => $require_for_package
     }
     # install the prerequired package if it is not set to empty string
-    if $package_prerequired == true {
+    unless $package_prerequired == "" {
       file { "/opt/${package_prerequired}.${package_file_suffix}":
 	    ensure => file,
 	    source => "puppet:///modules/pbis/${package_prerequired}.${package_file_suffix}",

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -27,7 +27,7 @@ class pbis (
   if $use_repository == true {
     # If the package is on an external repo, install it normally.
     package { $package:
-      ensure => installed,
+      ensure => latest,
     }
   }
   elsif $use_repository == false {
@@ -51,7 +51,7 @@ class pbis (
       source  => "puppet:///modules/pbis/${package}.${package_file_suffix}",
     }
     package { $package:
-      ensure   => installed,
+      ensure   => latest,
       source   => "/opt/${package}.${package_file_suffix}",
       provider => $package_file_provider,
       require  => $require_for_package
@@ -63,7 +63,7 @@ class pbis (
 	    source => "puppet:///modules/pbis/${package_prerequired}.${package_file_suffix}",
 	  }
       package { $package_prerequired:
-        ensure   => installed,
+        ensure   => latest,
         source   => "/opt/${package_prerequired}.${package_file_suffix}",
         provider => $package_file_provider,
         require  => File["/opt/${package_prerequired}.${package_file_suffix}"],

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -37,11 +37,11 @@ class pbis (
     # Compatibilitity switch for pbis <= v7.1.0
     # require also the prerequired package if it is not set to empty string
     if $package_prerequired == "" {
-	  $require_for_package = File["/opt/${package_prerequired}.${package_file_suffix}"]
+	  $require_for_package = File["/opt/${package}.${package_file_suffix}"]
     }
     else {
       $require_for_package = [
-        File["/opt/${package_prerequired}.${package_file_suffix}"],
+        File["/opt/${package}.${package_file_suffix}"],
         Package[$package_prerequired]
       ]
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -37,12 +37,12 @@ class pbis::params {
   # automatically.
   $package_file_suffix = $::osfamily ? {
     'Debian'          => "${::architecture}.deb",
-    '/(RedHat|Suse)/' => "${::architecture}.rpm",
+    /(RedHat|Suse)/ => "${::architecture}.rpm",
     default           => fail("Unsupported operating system: ${::operatingsystem}."),
   }
   $package_file_provider = $::osfamily ? {
     'Debian'          => 'dpkg',
-    '/(RedHat|Suse)/' => 'rpm',
+    /(RedHat|Suse)/ => 'rpm',
     default           => fail("Unsupported operating system: ${::operatingsystem}."),
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,6 +4,11 @@ class pbis::params {
   $use_repository        = false
   $package               = 'pbis-open'
   $service_name          = 'lsass'
+  
+  # parameter ignored when using repository, but needed when using builtin
+  # fileserver after pbis v7.1.1 (see bug #3)
+  # set this to empty string to disable the preinstallation
+  $package_prerequired   = 'pbis-open-upgrade'
 
   # domainjoin-cli options
   $ou                    = undef
@@ -30,9 +35,9 @@ class pbis::params {
   # PBIS Open is packaged for Red Hat, Suse, and Debian derivatives.
   # When using Puppet's built-in fileserver, choose the .deb or .rpm 
   # automatically.
-  $package_file = $::osfamily ? {
-    'Debian'          => "${package}.${::architecture}.deb",
-    '/(RedHat|Suse)/' => "${package}.${::architecture}.rpm",
+  $package_file_suffix = $::osfamily ? {
+    'Debian'          => "${::architecture}.deb",
+    '/(RedHat|Suse)/' => "${::architecture}.rpm",
     default           => fail("Unsupported operating system: ${::operatingsystem}."),
   }
   $package_file_provider = $::osfamily ? {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -37,12 +37,12 @@ class pbis::params {
   # automatically.
   $package_file_suffix = $::osfamily ? {
     'Debian'          => "${::architecture}.deb",
-    /(RedHat|Suse)/ => "${::architecture}.rpm",
+    /(RedHat|Suse)/   => "${::architecture}.rpm",
     default           => fail("Unsupported operating system: ${::operatingsystem}."),
   }
   $package_file_provider = $::osfamily ? {
     'Debian'          => 'dpkg',
-    /(RedHat|Suse)/ => 'rpm',
+    /(RedHat|Suse)/   => 'rpm',
     default           => fail("Unsupported operating system: ${::operatingsystem}."),
   }
 }


### PR DESCRIPTION
Related to #3
pbis-open-upgrade package will now defaultly be considered when using puppets fileserver for installing the pbis-open package.
Added legacy support including example in Readme how to use when you want install the older pbis-open packages
