### PR TITLE
Allow multiple values for RequireMembershipOf

### DIFF
--- a/templates/pbis.conf.erb
+++ b/templates/pbis.conf.erb
@@ -8,5 +8,4 @@ HomeDirUmask "<%= home_dir_umask -%>"
 LoginShellTemplate "<%= login_shell_template -%>"
 SkeletonDirs "<%= skeleton_dirs -%>"
 UserDomainPrefix "<%= user_domain_prefix -%>"
-<% if @require_membership_of -%>RequireMembershipOf "<%= require_membership_of -%>"<% end -%>
-
+<% if @require_membership_of -%>RequireMembershipOf <% @require_membership_of.each do |val| -%> "<%= val -%>" <% end -%> <% end -%>


### PR DESCRIPTION
Update pbis.conf.erb template to check for require_membership_of as an array and write group(s) in proper format.
