### PR TITLE
Added flag to control triggering of the update-dns command

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,6 +21,7 @@ class pbis (
   $skeleton_dirs         = $pbis::params::skeleton_dirs,
   $user_domain_prefix    = $pbis::params::user_domain_prefix,
   $use_repository        = $pbis::params::use_repository,
+  $do_updatedns          = $pbis::params::do_updatedns,
   ) inherits pbis::params {
 
   if $use_repository == true {
@@ -89,11 +90,13 @@ class pbis (
   }
 
   # Update DNS
-  exec { 'update_DNS':
-    path    => ['/opt/pbis/bin'],
-    command => 'update-dns',
-    require => Exec['join_domain'],
-    returns => [0, 204],
+  if $do_updatedns == true {
+    exec { 'update_DNS':
+      path    => ['/opt/pbis/bin'],
+      command => 'update-dns',
+      require => Exec['join_domain'],
+      returns => [0, 204],
+    }
   }
 
   # Configure PBIS

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,6 +4,7 @@ class pbis::params {
   $use_repository        = false
   $package               = 'pbis-open'
   $service_name          = 'lsass'
+  $do_updatedns          = true
 
   # domainjoin-cli options
   $ou                    = undef


### PR DESCRIPTION
Running the /opt/pbis/bin/update-dns command counts as an applied resource, and thus throws out reporting.
